### PR TITLE
rc: Set powerdxx_enable properly

### DIFF
--- a/powerd++.rc
+++ b/powerd++.rc
@@ -9,6 +9,9 @@
 
 name="powerdxx"
 rcvar="powerdxx_enable"
+
+: "${powerdxx_enable:="NO"}"
+
 command="%%PREFIX%%/sbin/powerd++"
 pidfile="/var/run/powerd.pid"
 


### PR DESCRIPTION
The rc(8) framework complains about powerdxx_enable not being set correctly:

> /usr/local/etc/rc.d/powerdxx: WARNING: $powerdxx_enable is not set properly - see rc.conf(5).